### PR TITLE
QR Code Validator: Is thirdParty if the input does NOT include vaccine-ontario.ca

### DIFF
--- a/src/services/QRCodeValidator/QRCodeValidator.ts
+++ b/src/services/QRCodeValidator/QRCodeValidator.ts
@@ -121,7 +121,7 @@ export default class QRCodeValidator {
       }
       return {
         valid: false,
-        thirdParty: input.includes('vaccine-ontario.ca'),
+        thirdParty: !input.includes('vaccine-ontario.ca'),
         multi:
           this.#totalChunks !== undefined
             ? {


### PR DESCRIPTION
# NOT TESTED

I was skimming through the validation code to see how it worked and I noticed this. Maybe this change isn't correct but it looks like it's treating Ontario stuff as third party. If this change is incorrect, then it's worth adding a comment in the code about why that specific string means third party. `thirdParty` is used in Scanner.tsx be analytics.