### PR TITLE
QR Code Decoder: Correct evenLengthDigitsRegex

### DIFF
--- a/src/services/QRCodeValidator/lib/decodeQR.ts
+++ b/src/services/QRCodeValidator/lib/decodeQR.ts
@@ -23,7 +23,7 @@ import {Key} from './models/Jwks';
 import {VC, FhirBundle} from './models/VC';
 
 const ec = new EC('p256');
-const evenLengthDigitsRegex = /\d{2}/g;
+const evenLengthDigitsRegex = /^(\d{2})+$/g;
 
 interface decodeQRResult {
   credential: SHCJWTPayload;


### PR DESCRIPTION
# NOT TESTED

The regex currently only checks that the string contains 2 consecutive digits. It matches '123' and 'a 12'.