### PR TITLE
Fix incorrect string matching.

### DIFF
--- a/src/services/QRCodeValidator/QRCodeValidator.ts
+++ b/src/services/QRCodeValidator/QRCodeValidator.ts
@@ -121,7 +121,7 @@ export default class QRCodeValidator {
       }
       return {
         valid: false,
-        thirdParty: input.includes('vaccine-ontario.ca'),
+        thirdParty: input.endsWith('vaccine-ontario.ca'),
         multi:
           this.#totalChunks !== undefined
             ? {


### PR DESCRIPTION
Using includes is incorrect, as it would match things like `vaccine-ontario.ca.totally.different.randomdomain.tk`.